### PR TITLE
Add a matrix of Python versions to main Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: python app
+name: main
 
 on:
   push:
@@ -10,12 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.9", "3.10"]
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python }}
       - name: Test
         run: |
           python -m unittest


### PR DESCRIPTION
Add Python 3.10 to GitHub Actions for testing.  Generalizes the steps of the build job to make the addition of Python versions easier to manage.